### PR TITLE
Respect all params of menuItems

### DIFF
--- a/administrator/modules/mod_submenu/tmpl/default.php
+++ b/administrator/modules/mod_submenu/tmpl/default.php
@@ -39,41 +39,52 @@ $user = $app->getIdentity();
 				<ul class="list-group list-group-flush">
 					<?php foreach ($child->getChildren() as $item) : ?>
 						<li class="list-group-item">
-							<a href="<?php echo $item->link; ?>"><?php echo Text::_($item->title); ?>
-								<?php if ($item->ajaxbadge) : ?>
-									<span class="menu-badge"><span class="fa fa-spin fa-spinner mt-1 system-counter" data-url="<?php echo $item->ajaxbadge; ?>"></span></span>
-								<?php endif; ?>
-							</a>
-							<?php if ($item->getParams()->get('menu-quicktask', false)) : ?>
-								<?php
-								$params = $item->getParams();
-								$link = $params->get('menu-quicktask-link');
-								$icon = $params->get('menu-quicktask-icon', 'plus');
-								$title = $params->get('menu-quicktask-title', 'MOD_MENU_QUICKTASK_NEW');
-								$permission = $params->get('menu-quicktask-permission');
-								$scope = $item->scope !== 'default' ? $item->scope : null;
-								?>
-								<?php if (!$permission || $user->authorise($permission, $scope)) : ?>
-									<span class="menu-quicktask"><a href="<?php echo $link; ?>">
-										<span class="fa fa-<?php echo $icon; ?>" title="<?php echo htmlentities(Text::_($title)); ?>" aria-hidden="true"></span>
-										<span class="sr-only"><?php echo Text::_($title); ?></span>
-									</a></span>
-								<?php endif; ?>
-							<?php endif; ?>
-							<?php if ($item->dashboard) : ?>
-								<span class="menu-dashboard">
-									<a href="<?php echo JRoute::_('index.php?option=com_cpanel&view=cpanel&dashboard=' . $item->dashboard); ?>">
-										<span class="fa fa-th-large" title="<?php echo htmlentities(Text::_('MOD_MENU_DASHBOARD_LINK')); ?>"></span>
-									</a>
+							<?php $params = $item->getParams(); ?>
+							<?php // Only if Menu-show = true
+								if ($params->get('menu_show', 1)) : ?>
+								<?php 
+								if (!empty($params->get('menu_image'))) :
+									$image = htmlspecialchars( $params->get('menu_image'), ENT_QUOTES, 'UTF-8');
+									$class = htmlspecialchars($params->get('menu_image_css'), ENT_QUOTES, 'UTF-8');
+									$alt = $params->get('menu_text') ? '' : htmlspecialchars($item->title, ENT_QUOTES, 'UTF-8');
+								endif; 
+								?>	
+								<a href="<?php echo $item->link; ?>">
+									<?php if (!empty($params->get('menu_image'))) : ?>
+										<?php echo  HTMLHelper::_('image', $image, $alt, 'class="' . $class . '"'); ?>
+									<?php endif; ?>
+									<?php echo ($params->get('menu_text', 1)) ? Text::_($item->title) : '';  ?>
+								</a>
+								<span class="menu-quicktask">
+									<?php if ($params->get('menu-quicktask', false)) : ?>
+										<?php
+										$link = $params->get('menu-quicktask-link');
+										$icon = $params->get('menu-quicktask-icon', 'plus');
+										$title = $params->get('menu-quicktask-title', 'MOD_MENU_QUICKTASK_NEW');
+										$permission = $params->get('menu-quicktask-permission');
+										$scope = $item->scope !== 'default' ? $item->scope : null;
+										?>
+										<?php if (!$permission || $user->authorise($permission, $scope)) : ?>
+											<a href="<?php echo $link; ?>">
+												<span class="fa fa-<?php echo $icon; ?>" title="<?php echo htmlentities(Text::_($title)); ?>" aria-hidden="true"></span>
+												<span class="sr-only"><?php echo Text::_($title); ?></span>
+											</a>
+										<?php endif; ?>
+									<?php endif; ?>
 								</span>
+								<span class="menu-badge">
+									<?php if ($item->ajaxbadge) : ?>
+										<span class="fa fa-spin fa-spinner mt-1 system-counter" data-url="<?php echo $item->ajaxbadge; ?>"></span>
+									<?php endif; ?>
+								</span>
+								<?php if ($item->dashboard) : ?>
+									<span class="menu-dashboard">
+										<a href="<?php echo JRoute::_('index.php?option=com_cpanel&view=cpanel&dashboard=' . $item->dashboard); ?>">
+											<span class="fa fa-th-large" title="<?php echo htmlentities(Text::_('MOD_MENU_DASHBOARD_LINK')); ?>"></span>
+										</a>
+									</span>
+								<?php endif; ?>
 							<?php endif; ?>
-							<?php
-							$params = json_decode($item->params);
-							if (!empty($params->menu_image)) :
-								$image = htmlspecialchars($params->menu_image, ENT_QUOTES, 'UTF-8');
-								$class = htmlspecialchars($params->menu_image_css, ENT_QUOTES, 'UTF-8');
-								echo  HTMLHelper::_('image', $image, '', 'class="' .$class . '"');
-							endif; ?>
 						</li>
 					<?php endforeach; ?>
 				</ul>

--- a/administrator/templates/atum/scss/blocks/_global.scss
+++ b/administrator/templates/atum/scss/blocks/_global.scss
@@ -48,7 +48,7 @@ textarea {
 
   &:focus,
   &:-moz-focusring {
-    outline: auto 2px var(--focus);
+  outline: auto 2px var(--focus);
   }
 }
 
@@ -153,6 +153,13 @@ caption {
   opacity: 1;
 }
 
+// dashboard items
+.menu-quicktask,
+.menu-badge {
+  float: right;
+  min-width: 1rem;
+}
+
 // extern links with icons
 a[href*="//"]:before {
   font: normal normal normal 14px/1 FontAwesome;
@@ -166,7 +173,6 @@ a[href*="//"]:before {
     }
   }
 }
-
 
 
 


### PR DESCRIPTION
### Summary of Changes
Respect all Parmeters of the menuItem.

If it is a hidden menuItem: don't show
If an image is selected, show the image, with the image class.
If the switch "show text" os off, don't show the text but make an alt-Text for the image.

Place badge and qickicon right