### PR TITLE
Add-button smaller on screens md-up

### DIFF
--- a/administrator/templates/atum/scss/blocks/_quickicons.scss
+++ b/administrator/templates/atum/scss/blocks/_quickicons.scss
@@ -51,6 +51,10 @@
     border-top: 1px solid $light_blue;
     text-decoration: none;
 
+    @include media-breakpoint-up(md) {
+      line-height: 2rem;
+    }
+	
     @include hover-focus-active {
       text-decoration: none;
       box-shadow: $quickicon-box-shadow-hover;


### PR DESCRIPTION
### Summary of Changes
The add button for quickicons is linehight 3.4 rem on small devices, 2rem in md-uo
