### PR TITLE
Change icon coq

### DIFF
--- a/administrator/components/com_menus/presets/joomla.xml
+++ b/administrator/components/com_menus/presets/joomla.xml
@@ -249,7 +249,7 @@
 			title="MOD_MENU_SYSTEM"
 			type="component"
 			element="com_cpanel"
-			class="class:cog"
+			class="class:wrench"
 			link="index.php?option=com_cpanel&amp;view=cpanel&amp;dashboard=system"
 	/>
 	<menuitem

--- a/administrator/components/com_menus/presets/modern.xml
+++ b/administrator/components/com_menus/presets/modern.xml
@@ -6,7 +6,7 @@
 	<menuitem
 		title="MOD_MENU_SYSTEM"
 		type="heading"
-		class="class:cog"
+		class="class:wrench"
 		>
 		<menuitem
 			type="component"

--- a/administrator/components/com_menus/presets/system.xml
+++ b/administrator/components/com_menus/presets/system.xml
@@ -7,7 +7,7 @@
     <menuitem
         title="COM_CPANEL_SYSTEM_SETUP"
         type="heading"
-        icon="cog"
+        icon="wrench"
         permission="core.admin"
     >
         <menuitem

--- a/administrator/modules/mod_submenu/tmpl/default.php
+++ b/administrator/modules/mod_submenu/tmpl/default.php
@@ -28,7 +28,7 @@ $user = $app->getIdentity();
 	<?php if (Factory::getUser()->authorise('core.edit', 'com_modules')) : ?>
 	<div class="module-actions">
 		<a href="<?php echo 'index.php?option=com_modules&task=module.edit&id=' . (int) $module->id; ?>">
-			<span class="fa fa-cog"><span class="sr-only"><?php echo Text::_('JACTION_EDIT') . ' ' . $module->title; ?></span></span>
+			<span class="fa fa-edit"><span class="sr-only"><?php echo Text::_('JACTION_EDIT') . ' ' . $module->title; ?></span></span>
 		</a>
 	</div>
 	<?php endif; ?>

--- a/administrator/templates/atum/html/layouts/chromes/well.php
+++ b/administrator/templates/atum/html/layouts/chromes/well.php
@@ -45,7 +45,7 @@ if ($module->content) :
 
 				<div class="module-actions dropdown">
 					<a data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" id="dropdownMenuButton-<?php echo $id; ?>">
-						<span class="fa fa-cog"><span class="sr-only">
+						<span class="fa fa-edit"><span class="sr-only">
 							<?php echo Text::_('JACTION_EDIT') . ' ' . $module->title; ?>
 						</span></span>
 					</a>

--- a/administrator/templates/atum/html/layouts/chromes/well.php
+++ b/administrator/templates/atum/html/layouts/chromes/well.php
@@ -45,7 +45,7 @@ if ($module->content) :
 
 				<div class="module-actions dropdown">
 					<a data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" id="dropdownMenuButton-<?php echo $id; ?>">
-						<span class="fa fa-edit"><span class="sr-only">
+						<span class="fa fa-cog"><span class="sr-only">
 							<?php echo Text::_('JACTION_EDIT') . ' ' . $module->title; ?>
 						</span></span>
 					</a>


### PR DESCRIPTION
Pull Request for Issue 132# .

### Summary of Changes
The coq icon for system is replaced by wrench. 

The coq icon for editing a admin module is replaced by a edit icon.

![change-icon-coq](https://user-images.githubusercontent.com/1035262/55987680-5dd1d200-5ca2-11e9-991c-f058790a4fea.PNG)


