### PR TITLE
[4.0] Add Lock icon to login button

### DIFF
--- a/administrator/modules/mod_login/tmpl/default.php
+++ b/administrator/modules/mod_login/tmpl/default.php
@@ -91,7 +91,10 @@ Text::script('JHIDE');
 			</div>
 		<?php endif; ?>
 		<div class="form-group">
-			<button class="btn btn-primary btn-block btn-lg mt-4" id="btn-login-submit"><?php echo Text::_('JLOGIN'); ?></button>
+			<button class="btn btn-primary btn-block btn-lg mt-4" id="btn-login-submit">
+				<span class="icon-lock icon-white" aria-hidden="true"></span>
+				<?php echo '&#160;'.Text::_('JLOGIN'); ?>
+			</button>
 		</div>
 		<input type="hidden" name="option" value="com_login">
 		<input type="hidden" name="task" value="login">


### PR DESCRIPTION
This PR adds lock icon to login button in the administrator login

### After patch
![login1](https://user-images.githubusercontent.com/34353697/56235988-37e36d80-60a6-11e9-9744-ebdefd9f7b7e.png)


### 3.x
Also in 3.x there was a lock icon
![login2](https://user-images.githubusercontent.com/34353697/56236050-53e70f00-60a6-11e9-89b5-844b312816f1.png)


