### PR TITLE
Correct quickicon classes for e.g. loading icon

### DIFF
--- a/administrator/templates/atum/scss/_variables.scss
+++ b/administrator/templates/atum/scss/_variables.scss
@@ -2,7 +2,7 @@
 @import "../../../../media/vendor/bootstrap/scss/functions";
 
 $white:                            #fff;
-$whiteoffset:					   #fefefe;
+$whiteoffset:                      #fefefe;
 $gray-100:                         #f8f9fa;
 
 $gray-200:                         #e8e8e8; //used in bootstrap .badge-inverse
@@ -14,7 +14,7 @@ $gray-700:                         #495057; //used for atum-text-dark, secondary
 $gray-800:                         #343a40; //used for badges-inverse
 $gray-900:                         #212529; //used for tree header, badge-inverse border
 $black:                            #000;	//used for shadows
-$focuscolor:						#39f;   //used for focus color
+$focuscolor:                       #39f;   //used for focus color
 
 $dark-blue:                        #001B4C; //is the atum-special-color
 
@@ -28,7 +28,7 @@ $red:                              #c52827; //used in bootstrap
 $red-dark:                         #3b0d0c; //used for alerts error
 $yellow:                           #d43900; //used in bootstrap
 $green:                            #2f7d32; //used in bootstrap
-$green-dark:                       #0f2f21; // used for alert success
+$green-dark:                       #0f2f21; //used for alert success
 $teal:                             #20c997; //used in bootstrap
 $cyan:                             #108193; //used in bootstrap
 
@@ -65,11 +65,10 @@ $theme-colors: map-merge((
   atum-bg-dark:                    $color-60, //standard background color
   action:                          $color-60,
   error:                           $red-dark,
-  alert-success:                    $green-dark
+  alert-success:                   $green-dark
 ), $theme-colors);
 
 $colors: (
-
   card-bg:                         $white,
   toolbar-bg:                      lighten($gray-200, 5%), // % VON DASHBOARD BG BZW ATUM lIGHT BG
   success-border:                  theme-color("success"),
@@ -132,7 +131,7 @@ $h4-font-size:                     1rem;
 $h5-font-size:                     .9286rem;
 $h6-font-size:                     .8571rem;
 $font-size-sm:                     .8rem;
-$font-size-vsm:                     .6rem;
+$font-size-vsm:                    .6rem;
 $display1-size:                    1rem;
 $display2-size:                    .875rem;
 $content-font-size:                0.875rem;
@@ -202,21 +201,21 @@ $state-danger-text:                var(--white);
 $state-danger-bg:                  var(--danger);
 $state-danger-border:              var(--danger-border);
 
-$state-error-text:                var(--error);
-$state-error-bg:                  lighten($red-dark, 70%);
-$state-error-border:              lighten($red-dark, 30%);
+$state-error-text:                 var(--error);
+$state-error-bg:                   lighten($red-dark, 70%);
+$state-error-border:               lighten($red-dark, 30%);
 
 
 
 // Badges
 $success-bg:                       #a2f5bf;
-$success-txt:                     #0f2f21;
+$success-txt:                      #0f2f21;
 
 $warning-bg:                       #fcd9b6;
-$warning-txt:                     #462a16;
+$warning-txt:                      #462a16;
 
 $danger-bg:                        #f9acaa;
-$danger-txt:                      #3b0d0c;
+$danger-txt:                       #3b0d0c;
 
 // Input Group
 $input-group-addon-color:          var(--white);
@@ -234,19 +233,22 @@ $list-group-bg:                    var(--white-offset);
 $custom-select-bg:                 var(--white-offset);
 
 //input
-$input-padding:						        .6rem 1rem;
-$input-select-padding:				    .6rem 3rem .6rem 1rem;
-$input-select-multiple-padding:		.3rem 1rem;
+$input-padding:                    .6rem 1rem;
+$input-select-padding:             .6rem 3rem .6rem 1rem;
+$input-select-multiple-padding:    .3rem 1rem;
 
 // Modals
 $modal-header-height:              2.875rem;
 
 // Quickicons
 $quickicon-bg:                     var(--white);
+$quickicon-color-hover:            rgba(255, 255, 255, 0.9);
 $quickicon-box-shadow:             $atum-box-shadow;
 $quickicon-box-shadow-success:     0 0 3px 0 var(--success);
 $quickicon-box-shadow-danger:      0 0 3px 0 var(--danger);
 $quickicon-box-shadow-warning:     0 0 3px 0 var(--warning);
+$quickicon-icon-size:              1.3rem;
+$quickicon-icon-size-big:          2rem;
 
 // Gutter
 $grid-gutter-width:                2rem;

--- a/administrator/templates/atum/scss/blocks/_quickicons.scss
+++ b/administrator/templates/atum/scss/blocks/_quickicons.scss
@@ -24,213 +24,11 @@
       @include hover-focus-active {
         text-decoration: none;
         box-shadow: $atum-box-shadow;
-        color:rgba(255,255,255,0.9);
-        background: var(--atum-link-color);
-      }
-    }
-  }
-
-  .quickicon-name {
-    font-size: $display2-size;
-    padding-bottom: .6rem;
-  }
-
-  .quickicon-amount {
-    font-size: $display1-size;
-    font-weight: 700;
-    padding: .3rem;
-    margin-top: .3rem !important;
-  }
-
-  .thsd {
-    font-size: 0.9rem;
-    letter-spacing: normal;
-    font-weight: normal;
-  }
-
-  .quickicon-text {
-    min-height: 1.2rem;
-  }
-
-  .quickicon-linkadd {
-    position: relative;
-    overflow: hidden;
-    font-size: $display2-size;
-    color: var(--atum-text-dark);
-    line-height: 2rem;
-    margin-top: 0.4rem;
-    border: 1px solid $gray-400;
-    text-decoration: none;
-    text-align: center;
-    display: inline-block;
-    box-shadow: $atum-box-shadow;
-
-    @include media-breakpoint-up(md) {
-      line-height: 2rem;
-    }
-
-    @include hover-focus-active {
-      text-decoration: none;
-      box-shadow: $atum-box-shadow;
-      color:rgba(255,255,255,0.9);
-      background: var(--atum-link-color);
-    }
-
-    .fa {
-      position: absolute;
-      left: 0;
-      display: inline-block;
-      width: 32px;
-      height: auto;
-      line-height: 2rem;
-      color: var(--white);
-      background-color: var(--atum-link-color);
-      text-align: center;
-
-      @include media-breakpoint-up(md) {
-        line-height: 2rem;
-      }
-
-    }
-
-    span:last-child {
-      margin-left: 32px;
-    }
-  }
-
-  a:not(.quickicon-linkadd) {
-    display: inline-flex;
-    min-height: 5.7rem;
-    flex-direction: column;
-    width: 100%;
-    transition: all .25s ease;
-    text-align: center;
-    border: 1px solid $gray-400;
-    background-color: var(--toolbar-bg);
-    color: var(--atum-text-dark);
-    line-height: 1.1;
-    align-self: baseline;
-    border-radius: $border-radius-s;
-    box-shadow: $atum-box-shadow;
-
-    @include hover-focus-active {
-      text-decoration: none;
-
-      .fa {
-        color: rgba(255,255,255,0.9);
+        color: $quickicon-color-hover;
+        background: $link-color;
       }
     }
 
-    > div {
-      flex: 1 0 0;
-      margin: 0 auto;
-    }
-
-    .j-links-link {
-      display: block;
-      width: 100%;
-      padding: 0 1rem;
-      line-height: 1.1;
-    }
-
-    .fa,
-    .fab {
-      margin: .8rem auto 0;
-      font-size: 1.3rem;
-      color: var(--atum-link-color);
-    }
-
-    .fa-images,
-    .fa-paint-brush,
-    #plg_quickicon_privacycheck .fa-users,
-    .fa-file,
-    .fa-star,
-    .fa-joomla,
-    .fa-cog {
-      font-size: 2rem;
-    }
-
-    &.warning {
-      background: $danger-bg;
-      border: 1px solid lighten($danger-txt, 30%);
-
-      .fa,
-      .fab {
-        color: $danger-txt;
-      }
-
-      &:hover {
-        color:rgba(255,255,255,0.9);
-        background: var(--danger);
-
-        .fa,
-        .fab {
-          color:rgba(255,255,255,0.9);
-        }
-      }
-    }
-
-    &.danger {
-      background: $danger-bg;
-      border: 1px solid lighten($danger-txt, 30%);
-
-      .fa,
-      .fab {
-        color: $danger-txt;
-      }
-
-      &:hover {
-        color:rgba(255,255,255,0.9);
-        background: var(--danger);
-
-        .fa,
-        .fab {
-          color:rgba(255,255,255,0.9);
-        }
-      }
-    }
-
-    &.success {
-      border: 1px solid var(--success);
-
-      .fa,
-      .fab {
-        color: var(--success);
-      }
-
-      &:hover {
-        color:rgba(255,255,255,0.9);
-        background: var(--success);
-
-        .fa,
-        .fab {
-          color:rgba(255,255,255,0.9);
-        }
-      }
-    }
-  }
-}
-
-#content{
-  .menu-quicktask{
-    position: absolute;
-    right: 1.25rem;
-  }
-}
-
-.cpanel-quickicons{
-  .card-columns{
-    @include media-breakpoint-down(md) {
-      column-count: 2;
-    }
-    @include media-breakpoint-down(sm) {
-      column-count: 1;
-    }
-  }
-}
-
-.quick-icons {
-  li {
     @media (max-width: 1350px) {
       width: calc(50% - 1rem);
       max-width: calc(50% - 1rem);
@@ -252,7 +50,187 @@
       flex: 1 1 calc(100% - 1rem);
     }
   }
+
+  .quickicon-linkadd {
+    position: relative;
+    overflow: hidden;
+    font-size: $display2-size;
+    color: var(--atum-text-dark);
+    line-height: 2rem;
+    margin-top: 0.4rem;
+    border: 1px solid $gray-400;
+    text-decoration: none;
+    text-align: center;
+    display: inline-block;
+    box-shadow: $atum-box-shadow;
+
+    @include hover-focus-active {
+      text-decoration: none;
+      box-shadow: $atum-box-shadow;
+      color: $quickicon-color-hover;
+      background: var(--atum-link-color);
+    }
+
+    .fa {
+      position: absolute;
+      left: 0;
+      display: inline-block;
+      width: 2rem;
+      height: auto;
+      line-height: 2rem;
+      color: $quickicon-bg;
+      background-color: var(--atum-link-color);
+      text-align: center;
+    }
+
+    span:last-child {
+      margin-left: 1rem;
+    }
+  }
+
+  a:first-of-type {
+    display: inline-flex;
+    min-height: 5.7rem;
+    flex-direction: column;
+    width: 100%;
+    transition: all .25s ease;
+    text-align: center;
+    border: 1px solid $gray-400;
+    background-color: var(--toolbar-bg);
+    color: var(--atum-text-dark);
+    line-height: 1.1;
+    align-self: baseline;
+    border-radius: $border-radius-s;
+    box-shadow: $atum-box-shadow;
+
+    .fa,
+    .fab {
+      font-size: $quickicon-icon-size;
+      color: var(--atum-link-color);
+
+      &:hover {
+        color: $quickicon-color-hover;
+      }
+    }
+
+    &:hover {
+      color: $quickicon-color-hover;
+    }
+
+    @include hover-focus-active {
+      text-decoration: none;
+
+      .fa {
+        color: $quickicon-color-hover;
+      }
+    }
+
+    > div {
+      flex: 1 0 0;
+      margin: 0 auto;
+
+      &.quickicon-icon {
+        margin: .8rem auto 0;
+
+        &.big {
+          .fa,
+          .fab {
+            font-size: $quickicon-icon-size-big;
+          }
+        }
+      }
+    }
+
+    .quickicon-name {
+      font-size: $display2-size;
+      padding-bottom: .6rem;
+    }
+
+    .quickicon-amount {
+      font-size: $display1-size;
+      font-weight: $bold-weight;
+      padding: .3rem;
+      margin-top: .3rem !important;
+
+      > .fa-spinner {
+        font-size: $display1-size;
+      }
+    }
+
+    .quickicon-text {
+      min-height: 1.2rem;
+    }
+
+    .j-links-link {
+      display: block;
+      width: 100%;
+      padding: 0 1rem;
+      line-height: 1.1;
+    }
+
+    &.warning {
+      background: $danger-bg;
+      border: 1px solid lighten($danger-txt, 30%);
+
+      .fa,
+      .fab {
+        color: $danger-txt;
+      }
+
+      &:hover {
+        background: var(--danger);
+      }
+    }
+
+    &.danger {
+      background: $danger-bg;
+      border: 1px solid lighten($danger-txt, 30%);
+
+      .fa,
+      .fab {
+        color: $danger-txt;
+      }
+
+      &:hover {
+        background: var(--danger);
+      }
+    }
+
+    &.success {
+      border: 1px solid var(--success);
+
+      .fa,
+      .fab {
+        color: var(--success);
+      }
+
+      &:hover {
+        background: var(--success);
+      }
+    }
+  }
 }
+
+#content {
+  .menu-quicktask {
+    position: absolute;
+    right: 1.25rem;
+  }
+}
+
+.cpanel-quickicons {
+
+  .card-columns {
+    @include media-breakpoint-down(md) {
+      column-count: 2;
+    }
+
+    @include media-breakpoint-down(sm) {
+      column-count: 1;
+    }
+  }
+}
+
 #wrapper.closed {
   .quick-icons {
     li {

--- a/build/media_source/plg_quickicon_privacycheck/js/privacycheck.es6.js
+++ b/build/media_source/plg_quickicon_privacycheck/js/privacycheck.es6.js
@@ -11,7 +11,8 @@
     const ajaxUrl = variables.plg_quickicon_privacycheck_ajax_url;
     const url = variables.plg_quickicon_privacycheck_url;
     const text = variables.plg_quickicon_privacycheck_text;
-    const link = document.querySelector('#plg_quickicon_privacycheck span.j-links-link');
+    const quickicon = document.querySelector('#plg_quickicon_privacycheck');
+    const link = quickicon.querySelector('span.j-links-link');
 
     Joomla.request({
       url: ajaxUrl,
@@ -20,18 +21,18 @@
       perform: true,
       onSuccess: (response) => {
         try {
-          const requestList = JSON.parse(response);
+          const request = JSON.parse(response);
 
-          if (requestList.data.number_urgent_requests) {
+          if (request.data.number_urgent_requests) {
             // Quickicon on dashboard shows message
-            link.textContent = `${text.REQUESTFOUND} ${requestList.data.number_urgent_requests}`;
+            link.textContent = `${text.REQUESTFOUND} ${request.data.number_urgent_requests}`;
             // Quickicon becomes red
-            document.querySelector('#plg_quickicon_privacycheck').classList.add('danger');
+            quickicon.classList.add('danger');
 
             // Span in alert message
             const countSpan = document.createElement('span');
             countSpan.classList.add('label', 'label-important');
-            countSpan.textContent = requestList.data.number_urgent_requests;
+            countSpan.textContent = request.data.number_urgent_requests;
 
             // Button in alert to 'view requests'
             const requestButton = document.createElement('button');
@@ -49,13 +50,16 @@
             const container = document.querySelector('#system-message-container');
             container.insertBefore(div, container.firstChild);
           } else {
+            quickicon.classList.add('success');
             link.textContent = text.NOREQUEST;
           }
         } catch (e) {
+          quickicon.classList.add('danger');
           link.textContent = text.ERROR;
         }
       },
       onError: () => {
+        quickicon.classList.add('danger');
         link.textContent = text.ERROR;
       },
     });

--- a/layouts/joomla/quickicons/icon.php
+++ b/layouts/joomla/quickicons/icon.php
@@ -42,7 +42,7 @@ if ($id && ($displayData['id'] === 'plg_quickicon_joomlaupdate'
 }
 
 // Add the button class
-if (!empty($displayData['class']))
+if (!empty($displayData['class']) && is_string($displayData['class']))
 {
 	$tmp[] = $this->escape($displayData['class']);
 }

--- a/layouts/joomla/quickicons/icon.php
+++ b/layouts/joomla/quickicons/icon.php
@@ -14,8 +14,14 @@ use Joomla\CMS\Language\Text;
 $id      = empty($displayData['id']) ? '' : (' id="' . $displayData['id'] . '"');
 $target  = empty($displayData['target']) ? '' : (' target="' . $displayData['target'] . '"');
 $onclick = empty($displayData['onclick']) ? '' : (' onclick="' . $displayData['onclick'] . '"');
-$size    = isset($displayData['amount']) ? 'small' : 'big';
-$dataUrl = isset($displayData['ajaxurl']) ? 'data-url="' . $displayData['ajaxurl'] . '"' : '';
+
+if (isset($displayData['ajaxurl'])) {
+	$size = 'small';
+	$dataUrl = 'data-url="' . $displayData['ajaxurl'] . '"';
+} else {
+	$size = 'big';
+	$dataUrl = '';
+}
 
 // The title for the link (a11y)
 $title = empty($displayData['title']) ? '' : (' title="' . $this->escape($displayData['title']) . '"');


### PR DESCRIPTION
### Summary of Changes
The spin icon in quickicons was bigger than the loaded content. Also the "pulse" icons have correct classes now.

### Testing Instructions
Login to backend. Watch out for the quickicons with an icons that indicates loading and that they are not bigger than the content which is displayed afterwards. Icons like privacycheck have a green border when their result is successful.

### Actual result
The spinner icon is too big and pulse icons have a unnecessary class "1" too.
