### PR TITLE
change backgroundcolor for quickicons success on dashboard

### DIFF
--- a/administrator/templates/atum/scss/blocks/_quickicons.scss
+++ b/administrator/templates/atum/scss/blocks/_quickicons.scss
@@ -198,16 +198,23 @@
 
     &.success {
       color: $success-txt;
-      background:  $success-bg;
       border: 1px solid lighten($success-txt, 20%);
 
       .fa,
       .fab {
         color: var(--success);
+		
       }
 
       &:hover {
         background: var(--success);
+		color: var(--white);
+		.fa,
+		.fab {
+			&::before{
+				color: var(--white);
+			}				
+		}
       }
     }
   }


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
the background from the quickicons with state "success" should not have a green background.
changed to grey


### Testing Instructions



### Expected result



### Actual result



### Documentation Changes Required

