### PR TITLE
Set pagination to the right and style

### DIFF
--- a/administrator/templates/atum/scss/blocks/_layout.scss
+++ b/administrator/templates/atum/scss/blocks/_layout.scss
@@ -5,13 +5,17 @@
 
     &.current {
       padding: .5rem .75rem;
-      color: var(--atum-text-dark);
-      background-color: rgba($gray-300, 0.8);
+    }
+
+    &.current {
+      color: var(--atum-text-light);
+      background-color: var(--atum-bg-dark);
     }
 
     a {
-      padding: .5rem .75rem;
-      line-height: 2.25;
+      padding: .58rem .75rem;
+      line-height: 2.5;
+      text-decoration: none;
     }
   }
 
@@ -20,6 +24,12 @@
 
     &:hover {
       background: transparent;
+    }
+  }
+  a{
+    &:hover{
+      color: var(--atum-text-light);
+      background-color: var(--atum-bg-dark);
     }
   }
 }

--- a/administrator/templates/atum/scss/blocks/_layout.scss
+++ b/administrator/templates/atum/scss/blocks/_layout.scss
@@ -5,9 +5,6 @@
 
     &.current {
       padding: .5rem .75rem;
-    }
-
-    &.current {
       color: var(--atum-text-light);
       background-color: var(--atum-bg-dark);
     }

--- a/layouts/joomla/pagination/links.php
+++ b/layouts/joomla/pagination/links.php
@@ -63,7 +63,7 @@ if ($currentPage >= $step)
 			<?php endif; ?>
 
 			<?php if ($showPagesLinks) : ?>
-				<ul class="pagination ml-0 mb-4">
+				<ul class="pagination ml-auto mb-4 mr-0">
 					<?php echo LayoutHelper::render('joomla.pagination.link', $pages['start']); ?>
 					<?php echo LayoutHelper::render('joomla.pagination.link', $pages['previous']); ?>
 					<?php foreach ($pages['pages'] as $k => $page) : ?>


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes


Set pagination to the right and style 

### Testing Instructions

Test pagination  style

### Expected result

Pagination should now be right and the hover and active link color should be tum-text-light and atum-bg-dark

### Actual result

Pagination is left aligned

### Documentation Changes Required

No
