### PR TITLE
set btn-primary background color to atum-bg-dark

### DIFF
--- a/administrator/components/com_menus/Field/MenutypeField.php
+++ b/administrator/components/com_menus/Field/MenutypeField.php
@@ -90,7 +90,7 @@ class MenutypeField extends ListField
 		$link = Route::_('index.php?option=com_menus&view=menutypes&tmpl=component&client_id=' . $clientId . '&recordId=' . $recordId);
 		$html[] = '<span class="input-group"><input type="text" ' . $required . ' readonly="readonly" id="' . $this->id
 			. '" value="' . $value . '"' . $size . $class . '>';
-		$html[] = '<span class="input-group-append"><button type="button" data-target="#menuTypeModal" class="btn btn-secondary" data-toggle="modal">'
+		$html[] = '<span class="input-group-append"><button type="button" data-target="#menuTypeModal" class="btn btn-primary" data-toggle="modal">'
 			. '<span class="icon-list icon-white" aria-hidden="true"></span> '
 			. Text::_('JSELECT') . '</button></span></span>';
 		$html[] = HTMLHelper::_(

--- a/administrator/templates/atum/scss/_variables.scss
+++ b/administrator/templates/atum/scss/_variables.scss
@@ -53,7 +53,7 @@ $color-contrast:                   adjust-color($color-60, $hue: -30%, $lightnes
 $theme-colors: ();
 $theme-colors: map-merge((
   primary:                         $blue, //used only in bootstrap, please use $atum-bg-dark
-  secondary:                       $gray-700, //is it used?
+  secondary:                       $gray-700, //used for btn-secondary
   success:                         $green,
   info:                            $cyan,
   warning:                         $yellow,

--- a/administrator/templates/atum/scss/vendor/bootstrap/_buttons.scss
+++ b/administrator/templates/atum/scss/vendor/bootstrap/_buttons.scss
@@ -6,9 +6,9 @@
 }
 
 .btn-primary {
-  background-color: $white;
-  color: var(--atum-text-dark);
-  border-color: $gray-500;
+  background-color: var(--atum-bg-dark);
+  color: var(--atum-text-light);
+  border-color: var(--atum-bg-dark-80);
 
   @include hover-focus-active {
     background-color: var(--atum-bg-dark-70);
@@ -22,12 +22,8 @@
     border-color: var(--atum-bg-dark);
   }
 }
-
-.btn-secondary{
-	background-color:var(--atum-bg-dark);
-	&:hover{
-		background-color:var(--atum-bg-dark-80);
-	}
+.btn-secondary {
+	background-color: var(--atum-bg-dark-40);
 }
 
 .input-group-text {


### PR DESCRIPTION
set btn-secondary background color to atum-bg-dark-40
re-change in MenutypeField btn-secondary to btn-primary

Pull Request for Issue # .

### Summary of Changes



### Testing Instructions



### Expected result



### Actual result



### Documentation Changes Required

