### PR TITLE
Responsive header for install template

### DIFF
--- a/installation/template/index.php
+++ b/installation/template/index.php
@@ -53,6 +53,7 @@ Text::script('INSTL_FTP_SETTINGS_CORRECT');
 	<head>
 		<jdoc:include type="metas" />
 		<jdoc:include type="styles" />
+		<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 	</head>
 	<body data-basepath="<?php echo JUri::root(true); ?>">
 		<div class="j-install">

--- a/installation/template/index.php
+++ b/installation/template/index.php
@@ -53,19 +53,19 @@ Text::script('INSTL_FTP_SETTINGS_CORRECT');
 	<head>
 		<jdoc:include type="metas" />
 		<jdoc:include type="styles" />
-		<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
 	</head>
 	<body data-basepath="<?php echo JUri::root(true); ?>">
 		<div class="j-install">
 			<?php // Header ?>
 			<header id="header" class="header">
 				<div class="d-flex">
-					<div class="w-100 d-flex   mb-xs-3 ">
+					<div class="w-100 d-flex ">
 						<div class="logo d-none d-md-block"> 
 							<img src="<?php echo $this->baseurl; ?>/template/images/logo-joomla-blue.svg" alt=""/>
 						</div>
 						<div class="mx-2 d-flex d-md-none">
-							<img class="logo-small mx-2 d-flex d-md-none"src="<?php echo $this->baseurl; ?>/template/images/logo-blue.svg" alt="">
+							<img class="logo-small d-flex d-md-none" src="<?php echo $this->baseurl; ?>/template/images/logo-blue.svg" alt="">
 						</div>
 						<div class="d-flex flex-wrap align-items-center mx-auto">
 							<h1 class="h2 mx-1 d-flex align-items-baseline">

--- a/installation/template/index.php
+++ b/installation/template/index.php
@@ -51,9 +51,9 @@ Text::script('INSTL_FTP_SETTINGS_CORRECT');
 <!DOCTYPE html>
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
 	<head>
+		<meta name="viewport" content="width=device-width, initial-scale=1">
 		<jdoc:include type="metas" />
 		<jdoc:include type="styles" />
-		<meta name="viewport" content="width=device-width, initial-scale=1">
 	</head>
 	<body data-basepath="<?php echo JUri::root(true); ?>">
 		<div class="j-install">

--- a/installation/template/index.php
+++ b/installation/template/index.php
@@ -60,32 +60,30 @@ Text::script('INSTL_FTP_SETTINGS_CORRECT');
 			<?php // Header ?>
 			<header id="header" class="header">
 				<div class="d-flex">
-					<div class="header-title w-100 d-flex">
-						<div class="logo d-none d-md-block">
+					<div class="w-100 d-flex   mb-xs-3 ">
+						<div class="logo d-none d-md-block"> 
 							<img src="<?php echo $this->baseurl; ?>/template/images/logo-joomla-blue.svg" alt=""/>
 						</div>
-						<div class="d-flex">
-							<div class="logo-small mx-2 d-flex d-md-none">
-								<img src="<?php echo $this->baseurl; ?>/template/images/logo-blue.svg" alt="">
-							</div>
-							<div class="container-title d-flex flex-wrap align-items-center">
-								<h1 class="h2 mx-1 d-flex d-flex align-items-end">
-									<span class="fa fa-cogs d-none d-lg-block mx-2  alig-items-center" aria-hidden="true"></span>
-									<?php echo Text::_('INSTL_PAGE_TITLE'); ?>
-								</h1>
-								<div class="mx-1 d-flex align-items-baseline">
-									<span class="small ">Joomla! <?php echo (new Version)->getShortVersion(); ?></span>
-								</div>
-							</div>
+						<div class="mx-2 d-flex d-md-none">
+							<img class="logo-small mx-2 d-flex d-md-none"src="<?php echo $this->baseurl; ?>/template/images/logo-blue.svg" alt="">
 						</div>
-					</div>
-					<div class="mx-2 flex-shrink-1 d-flex align-items-center">
-						<a href="https://docs.joomla.org/Special:MyLanguage/J4.x:Installing_Joomla" target="_blank">
+						<div class="d-flex flex-wrap align-items-center mx-auto">
+							<h1 class="h2 mx-1 d-flex align-items-baseline">
+								<span class="fa fa-cogs d-none d-md-block mx-2 alig-items-center" aria-hidden="true"></span> 
+								<?php echo Text::_('INSTL_PAGE_TITLE'); ?>
+							</h1> 
+							<span class="small mx-1 d-flex align-items-baseline">
+								Joomla! <?php echo (new Version)->getShortVersion(); ?>
+							</span>
+						</div> 
+					</div> 
+					<div class="mx-2 d-flex flex-shrink-1 align-items-center"> 
+						<a href="https://docs.joomla.org/Special:MyLanguage/J4.x:Installing_Joomla"; target="_blank">
 							<span class="fa fa-question" aria-hidden="true"></span>
 							<span class="sr-only"><?php echo Text::_('INSTL_HELP_LINK'); ?></span>
-						</a>
-					</div>
-				</div>
+						</a> 
+					</div> 
+				</div> 
 			</header>
 			<?php // Container ?>
 			<div id="wrapper" class="d-flex wrapper flex-wrap">

--- a/installation/template/index.php
+++ b/installation/template/index.php
@@ -58,38 +58,31 @@ Text::script('INSTL_FTP_SETTINGS_CORRECT');
 		<div class="j-install">
 			<?php // Header ?>
 			<header id="header" class="header">
-				<div class="d-flex align-items-center">
-					<div class="header-title d-flex mr-auto">
-						<div class="d-flex">
-							<a class="logo" href="<?php echo Route::_('index.php'); ?>">
-								<img src="<?php echo $this->baseurl; ?>/template/images/logo-joomla-blue.svg" alt=""/>
-							</a>
+				<div class="d-flex">
+					<div class="header-title w-100 d-flex">
+						<div class="logo d-none d-md-block">
+							<img src="<?php echo $this->baseurl; ?>/template/images/logo-joomla-blue.svg" alt=""/>
 						</div>
-						<div class="d-flex px-2">
-							<div class="container-title">
-								<h1 class="page-title">
-									<span class="fa fa-cogs"></span>
+						<div class="d-flex">
+							<div class="logo-small mx-2 d-flex d-md-none">
+								<img src="<?php echo $this->baseurl; ?>/template/images/logo-blue.svg" alt="">
+							</div>
+							<div class="container-title d-flex flex-wrap align-items-center">
+								<h1 class="h2 mx-1 d-flex d-flex align-items-end">
+									<span class="fa fa-cogs d-none d-lg-block mx-2  alig-items-center" aria-hidden="true"></span>
 									<?php echo Text::_('INSTL_PAGE_TITLE'); ?>
 								</h1>
+								<div class="mx-1 d-flex align-items-baseline">
+									<span class="small ">Joomla! <?php echo (new Version)->getShortVersion(); ?></span>
+								</div>
 							</div>
 						</div>
 					</div>
-					<div class="header-items d-flex ml-auto">
-						<div class="d-flex align-items-center">
-							<p class="joomla-version w-100 text-right">
-								Joomla! <?php echo (new Version)->getShortVersion(); ?>
-							</p>
-						</div>
-						<div class="ml-auto">
-							<ul class="nav text-center">
-								<li class="nav-item">
-									<a class="nav-link" href="https://docs.joomla.org/Special:MyLanguage/J4.x:Installing_Joomla" target="_blank">
-										<span class="fa fa-question" aria-hidden="true"></span>
-										<span class="sr-only"><?php echo Text::_('INSTL_HELP_LINK'); ?></span>
-									</a>
-								</li>
-							</ul>
-						</div>
+					<div class="mx-2 flex-shrink-1 d-flex align-items-center">
+						<a href="https://docs.joomla.org/Special:MyLanguage/J4.x:Installing_Joomla" target="_blank">
+							<span class="fa fa-question" aria-hidden="true"></span>
+							<span class="sr-only"><?php echo Text::_('INSTL_HELP_LINK'); ?></span>
+						</a>
 					</div>
 				</div>
 			</header>


### PR DESCRIPTION
See title.
On large sceens, the joomla logo is displayed, the site title has a icon cogs.
On small screens, a small joomla replaces the other icons.
The Title is always visible in full length, the version is always visible.
