### PR TITLE
Remove padding from quickicons

### DIFF
--- a/administrator/templates/atum/scss/blocks/_quickicons.scss
+++ b/administrator/templates/atum/scss/blocks/_quickicons.scss
@@ -1,11 +1,8 @@
 // Quick Icons
 
-@import "../variables";
-
 .quick-icons {
   background-color: $white;
   margin-bottom: 1rem;
-  padding: 0.5rem 1.5rem;
 
   ul {
     list-style: none;


### PR DESCRIPTION
... because the chrome adds all the padding itself