### PR TITLE
codestyle jdoc:include

### DIFF
--- a/administrator/templates/atum/error_full.php
+++ b/administrator/templates/atum/error_full.php
@@ -150,9 +150,9 @@ $this->addStyleDeclaration($css);
 <!DOCTYPE html>
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
 <head>
-	<jdoc:include type="metas"/>
-	<jdoc:include type="styles"/>
-	<jdoc:include type="scripts"/>
+	<jdoc:include type="metas" />
+	<jdoc:include type="styles" />
+	<jdoc:include type="scripts" />
 </head>
 
 <body class="admin <?php echo $option . ' view-' . $view . ' layout-' . $layout . ($task ? ' task-' . $task : ''); ?>">
@@ -174,10 +174,10 @@ $this->addStyleDeclaration($css);
 					<img class="logo-small" src="<?php echo $smallLogo; ?>" alt="">
 				</a>
 			</div>
-			<jdoc:include type="modules" name="title"/>
+			<jdoc:include type="modules" name="title" />
 		</div>
 		<div class="header-items d-flex">
-			<jdoc:include type="modules" name="status" style="header-item"/>
+			<jdoc:include type="modules" name="status" style="header-item" />
 		</div>
 	</div>
 </header>
@@ -188,7 +188,7 @@ $this->addStyleDeclaration($css);
 	<?php // Sidebar ?>
 	<?php if (!$hiddenMenu) : ?>
 		<div id="sidebar-wrapper" class="sidebar-wrapper" <?php echo $hiddenMenu ? 'data-hidden="' . $hiddenMenu . '"' : ''; ?>>
-			<jdoc:include type="modules" name="menu" style="none"/>
+			<jdoc:include type="modules" name="menu" style="none" />
 			<div id="main-brand" class="main-brand d-flex align-items-center justify-content-center">
 				<img src="<?php echo $joomlaLogo; ?>" alt="">
 			</div>
@@ -206,14 +206,14 @@ $this->addStyleDeclaration($css);
 				<div id="container-collapse" class="container-collapse"></div>
 				<div class="row">
 					<div class="col-md-12">
-						<jdoc:include type="modules" name="toolbar" style="no"/>
+						<jdoc:include type="modules" name="toolbar" style="no" />
 					</div>
 				</div>
 			</div>
 		<?php endif; ?>
 		<section id="content" class="content">
 			<?php // Begin Content ?>
-			<jdoc:include type="modules" name="top" style="xhtml"/>
+			<jdoc:include type="modules" name="top" style="xhtml" />
 			<div class="row">
 				<div class="col-md-12">
 					<h1><?php echo Text::_('JERROR_AN_ERROR_HAS_OCCURRED'); ?></h1>
@@ -249,7 +249,7 @@ $this->addStyleDeclaration($css);
 				</div>
 
 				<?php if ($this->countModules('bottom')) : ?>
-					<jdoc:include type="modules" name="bottom" style="xhtml"/>
+					<jdoc:include type="modules" name="bottom" style="xhtml" />
 				<?php endif; ?>
 			</div>
 			<?php // End Content ?>
@@ -260,6 +260,6 @@ $this->addStyleDeclaration($css);
 		</div>
 	</div>
 </div>
-<jdoc:include type="modules" name="debug" style="none"/>
+<jdoc:include type="modules" name="debug" style="none" />
 </body>
 </html>

--- a/administrator/templates/atum/error_login.php
+++ b/administrator/templates/atum/error_login.php
@@ -66,8 +66,8 @@ $css = '
 <!DOCTYPE html>
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
 <head>
-	<jdoc:include type="metas"/>
-	<jdoc:include type="styles"/>
+	<jdoc:include type="metas" />
+	<jdoc:include type="styles" />
 </head>
 
 <body class="admin <?php echo $option . ' view-' . $view . ' layout-' . $layout; ?>">
@@ -97,7 +97,7 @@ $css = '
 			<a href="<?php echo Uri::root(); ?>"><?php echo Text::_('TPL_ATUM_LOGIN_SIDEBAR_VIEW_WEBSITE'); ?></a>
 		</div>
 		<div id="sidebar">
-			<jdoc:include type="modules" name="sidebar" style="body"/>
+			<jdoc:include type="modules" name="sidebar" style="body" />
 		</div>
 	</div>
 
@@ -111,7 +111,7 @@ $css = '
 							<img src="<?php echo $loginLogo; ?>" alt="">
 						</div>
 						<h1><?php echo Text::_('JERROR_AN_ERROR_HAS_OCCURRED'); ?></h1>
-						<jdoc:include type="message"/>
+						<jdoc:include type="message" />
 						<blockquote class="blockquote">
 							<span class="badge badge-secondary"><?php echo $this->error->getCode(); ?></span>
 							<?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?>
@@ -143,7 +143,7 @@ $css = '
 		</section>
 	</div>
 </div>
-<jdoc:include type="modules" name="debug" style="none"/>
-<jdoc:include type="scripts"/>
+<jdoc:include type="modules" name="debug" style="none" />
+<jdoc:include type="scripts" />
 </body>
 </html>

--- a/administrator/templates/atum/index.php
+++ b/administrator/templates/atum/index.php
@@ -201,9 +201,9 @@ $this->addStyleDeclaration($css);
 <!DOCTYPE html>
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
 <head>
-	<jdoc:include type="metas"/>
-	<jdoc:include type="styles"/>
-	<jdoc:include type="scripts"/>
+	<jdoc:include type="metas" />
+	<jdoc:include type="styles" />
+	<jdoc:include type="scripts" />
 </head>
 
 <body class="admin <?php echo $option . ' view-' . $view . ' layout-' . $layout . ($task ? ' task-' . $task : ''); ?>">
@@ -233,10 +233,10 @@ $this->addStyleDeclaration($css);
 					</a>
 				<?php endif; ?>
 			</div>
-			<jdoc:include type="modules" name="title"/>
+			<jdoc:include type="modules" name="title" />
 		</div>
 		<div class="header-items d-flex">
-			<jdoc:include type="modules" name="status" style="header-item"/>
+			<jdoc:include type="modules" name="status" style="header-item" />
 		</div>
 	</div>
 </header>
@@ -262,7 +262,7 @@ $this->addStyleDeclaration($css);
                        <span class="sidebar-item-title"><?php echo Text::_('TPL_ATUM_TOGGLE_SIDEBAR'); ?></span>
                   </a>
                 </div>
-                <jdoc:include type="modules" name="menu" style="none"/>
+                <jdoc:include type="modules" name="menu" style="none" />
             </div>
 		</div>
 	<?php endif; ?>
@@ -278,32 +278,32 @@ $this->addStyleDeclaration($css);
 				<div id="container-collapse" class="container-collapse"></div>
 				<div class="row">
 					<div class="col-md-12">
-						<jdoc:include type="modules" name="toolbar" style="no"/>
+						<jdoc:include type="modules" name="toolbar" style="no" />
 					</div>
 				</div>
 			</div>
 		<?php endif; ?>
 		<section id="content" class="content">
 			<?php // Begin Content ?>
-			<jdoc:include type="modules" name="top" style="xhtml"/>
+			<jdoc:include type="modules" name="top" style="xhtml" />
 			<div class="row">
 				<div class="col-md-12">
 					<main>
-						<jdoc:include type="component"/>
+						<jdoc:include type="component" />
 					</main>
 				</div>
 				<?php if ($this->countModules('bottom')) : ?>
-					<jdoc:include type="modules" name="bottom" style="xhtml"/>
+					<jdoc:include type="modules" name="bottom" style="xhtml" />
 				<?php endif; ?>
 			</div>
 			<?php // End Content ?>
 		</section>
 
 		<div class="notify-alerts">
-			<jdoc:include type="message"/>
+			<jdoc:include type="message" />
 		</div>
 	</div>
 </div>
-<jdoc:include type="modules" name="debug" style="none"/>
+<jdoc:include type="modules" name="debug" style="none" />
 </body>
 </html>

--- a/administrator/templates/atum/login.php
+++ b/administrator/templates/atum/login.php
@@ -262,8 +262,8 @@ $this->addStyleDeclaration($css);
 <!DOCTYPE html>
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
 <head>
-	<jdoc:include type="metas"/>
-	<jdoc:include type="styles"/>
+	<jdoc:include type="metas" />
+	<jdoc:include type="styles" />
 </head>
 
 <body class="admin <?php echo $option . ' view-' . $view . ' layout-' . $layout; ?>">
@@ -285,10 +285,10 @@ $this->addStyleDeclaration($css);
 					<img class="logo-small" src="<?php echo $smallLogo; ?>" alt="<?php echo $logoSmallAlt; ?>">
 				</div>
 			</div>
-			<jdoc:include type="modules" name="title"/>
+			<jdoc:include type="modules" name="title" />
 		</div>
 		<div class="header-items d-flex">
-			<jdoc:include type="modules" name="status" style="header-item"/>
+			<jdoc:include type="modules" name="status" style="header-item" />
 		</div>
 	</div>
 </header>
@@ -303,8 +303,8 @@ $this->addStyleDeclaration($css);
 						<img src="<?php echo $loginLogo; ?>"
 							 alt="<?php echo htmlspecialchars($this->params->get('altLoginLogo', ''), ENT_COMPAT, 'UTF-8'); ?>">
 					</div>
-					<jdoc:include type="message"/>
-					<jdoc:include type="component"/>
+					<jdoc:include type="message" />
+					<jdoc:include type="component" />
 				</div>
 			</main>
 		</section>
@@ -316,11 +316,11 @@ $this->addStyleDeclaration($css);
 			<h1><?php echo Text::_('TPL_ATUM_BACKEND_LOGIN'); ?></h1>
 		</div>
 		<div id="sidebar">
-			<jdoc:include type="modules" name="sidebar" style="body"/>
+			<jdoc:include type="modules" name="sidebar" style="body" />
 		</div>
 	</div>
 </div>
-<jdoc:include type="modules" name="debug" style="none"/>
-<jdoc:include type="scripts"/>
+<jdoc:include type="modules" name="debug" style="none" />
+<jdoc:include type="scripts" />
 </body>
 </html>


### PR DESCRIPTION
On the basis that all the documentation shows it with a space before the trailing `\>` and the other templates all do I have updated atum accordingly.

Pull Request for Issue #327 .

### Summary of Changes
changed `<jdoc:include....../>` to `<jdoc:include...... />`

### Testing Instructions
Code review 

### Documentation Changes Required
none
