### PR TITLE
Fix filter tags in com_categories

### DIFF
--- a/administrator/components/com_categories/forms/filter_categories.xml
+++ b/administrator/components/com_categories/forms/filter_categories.xml
@@ -38,6 +38,7 @@
 			<option value="">JOPTION_SELECT_LANGUAGE</option>
 			<option value="*">JALL</option>
 		</field>
+
 		<field
 			name="tag"
 			type="tag"
@@ -47,6 +48,7 @@
 			custom="false"
 			onchange="this.form.submit();"
 		/>
+
 		<field
 			name="level"
 			type="integer"

--- a/administrator/components/com_categories/forms/filter_categories.xml
+++ b/administrator/components/com_categories/forms/filter_categories.xml
@@ -43,6 +43,7 @@
 			name="tag"
 			type="tag"
 			multiple="true"
+			label="JOPTION_SELECT_TAG"
 			hint="JOPTION_SELECT_TAG"
 			mode="nested"
 			custom="false"

--- a/administrator/components/com_categories/forms/filter_categories.xml
+++ b/administrator/components/com_categories/forms/filter_categories.xml
@@ -38,18 +38,15 @@
 			<option value="">JOPTION_SELECT_LANGUAGE</option>
 			<option value="*">JALL</option>
 		</field>
-
 		<field
 			name="tag"
 			type="tag"
-			label="JOPTION_SELECT_TAG"
+			multiple="true"
+			hint="JOPTION_SELECT_TAG"
 			mode="nested"
 			custom="false"
 			onchange="this.form.submit();"
-			>
-			<option value="">JOPTION_SELECT_TAG</option>
-		</field>
-
+		/>
 		<field
 			name="level"
 			type="integer"

--- a/administrator/components/com_contact/forms/filter_contacts.xml
+++ b/administrator/components/com_contact/forms/filter_contacts.xml
@@ -54,11 +54,12 @@
 			name="tag"
 			type="tag"
 			label="JOPTION_SELECT_TAG"
+			multiple="true"
 			mode="nested"
+			custom="false"
+			hint="JOPTION_SELECT_TAG"
 			onchange="this.form.submit();"
-			>
-			<option value="">JOPTION_SELECT_TAG</option>
-		</field>
+		/>
 
 		<field
 			name="level"

--- a/administrator/components/com_content/forms/filter_articles.xml
+++ b/administrator/components/com_content/forms/filter_articles.xml
@@ -86,6 +86,7 @@
 			name="tag"
 			type="tag"
 			multiple="true"
+			label="JOPTION_SELECT_TAG"
 			hint="JOPTION_SELECT_TAG"
 			mode="nested"
 			custom="false"

--- a/administrator/components/com_content/forms/filter_featured.xml
+++ b/administrator/components/com_content/forms/filter_featured.xml
@@ -76,7 +76,7 @@
 		<field
 			name="tag"
 			type="tag"
-			labl="JOPTION_SELECT_TAG"
+			label="JOPTION_SELECT_TAG"
 			multiple="true"
 			mode="nested"
 			custom="false"

--- a/administrator/components/com_newsfeeds/forms/filter_newsfeeds.xml
+++ b/administrator/components/com_newsfeeds/forms/filter_newsfeeds.xml
@@ -53,12 +53,13 @@
 		<field
 			name="tag"
 			type="tag"
+			multiple="true"
 			label="JOPTION_SELECT_TAG"
+			hint="JOPTION_SELECT_TAG"
 			mode="nested"
+			custom="false"
 			onchange="this.form.submit();"
-			>
-			<option value="">JOPTION_SELECT_TAG</option>
-		</field>
+		/>
 
 		<field
 			name="level"


### PR DESCRIPTION
### Summary of Changes
Filter tags in com-categories changed to new layout. 

Old layout was : 
![filter-tag](https://user-images.githubusercontent.com/1035262/60768055-db01bd00-a0c0-11e9-9a56-a290c77de419.JPG)




