### PR TITLE
Inactive buttons contrast

### DIFF
--- a/administrator/templates/atum/scss/blocks/_header.scss
+++ b/administrator/templates/atum/scss/blocks/_header.scss
@@ -109,7 +109,7 @@
           background-color: transparent;
           color: var(--atum-special-color);
           box-shadow: none;
-          opacity: $btn-disabled-opacity;
+          
         }
       }
       .dropdown-toggle {

--- a/administrator/templates/atum/scss/blocks/_searchtools.scss
+++ b/administrator/templates/atum/scss/blocks/_searchtools.scss
@@ -82,6 +82,14 @@
         color: var(--atum-text-light);
         border:1px solid var(--border);
 		border-left: 0;
+		
+		&.disabled,
+		&:disabled{
+			background-color: rgba($gray-300, 0.8);
+			border-color: rgba($gray-500, 0.8);
+			opacity:1;
+			color:var(--atum-text-dark);
+		}
       }
 
       .form-control{

--- a/administrator/templates/atum/scss/blocks/_toolbar.scss
+++ b/administrator/templates/atum/scss/blocks/_toolbar.scss
@@ -231,6 +231,11 @@ joomla-toolbar-button {
       }
 
     }
+	
+	&.disabled,
+	&:disabled{
+		opacity:1;
+	}
   }
 
   .dropdown-item {

--- a/administrator/templates/atum/scss/vendor/bootstrap/_buttons.scss
+++ b/administrator/templates/atum/scss/vendor/bootstrap/_buttons.scss
@@ -23,7 +23,7 @@
   }
 }
 .btn-secondary {
-	background-color: var(--atum-bg-dark-40);
+	background-color: var(--atum-bg-dark-50);
 }
 
 .input-group-text {


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
remove opacity: 0.4 for the disabled buttons in toolbar and filter
change color clear-button (for filters) for disabled
change color for btn-secondary

Reason: contrast-ratio mentioned in [Issue 295](https://github.com/joomla/backend-template/issues/295)


### Testing Instructions
install this PR.


### Expected result
contrast-ratio should be better


### Actual result

contrast ratio to less

### Documentation Changes Required

