### PR TITLE
Switcher legend has same font-size as label.

### DIFF
--- a/administrator/templates/atum/scss/blocks/_form.scss
+++ b/administrator/templates/atum/scss/blocks/_form.scss
@@ -33,7 +33,7 @@
 
 .control-group {
   .switcher__legend {
-    font-size: $label-font-size
+    font-size: $label-font-size;
   }
 }
 

--- a/administrator/templates/atum/scss/blocks/_form.scss
+++ b/administrator/templates/atum/scss/blocks/_form.scss
@@ -31,6 +31,12 @@
   }
 }
 
+.control-group {
+  .switcher__legend {
+    font-size: $label-font-size
+  }
+}
+
 .form-no-margin {
 
   .control-group {


### PR DESCRIPTION
Switcher legend has a bigger font-size than other labels. 