### PR TITLE
Fix colorpicker value

### DIFF
--- a/build/media_source/system/js/fields/joomla-field-color-slider.es6.js
+++ b/build/media_source/system/js/fields/joomla-field-color-slider.es6.js
@@ -61,7 +61,8 @@
       // Attributes
       this.color = element.dataset.color || '';
       this.default = element.dataset.default || '';
-      this.format = element.dataset.format || 'hex';
+      this.format = this.input.dataset.format || 'hex';
+      this.saveFormat = this.mainInput.dataset.format || 'hex';
       this.preview = element.dataset.preview === 'true';
       this.setAlpha = this.format === 'hsla' || this.format === 'rgba';
 
@@ -126,7 +127,7 @@
       } else {
         this.showError('');
 
-        switch (this.input.dataset.format) {
+        switch (this.format) {
           case 'hue':
             hsl[0] = inputField.value;
             this.hue = inputField.value;
@@ -156,10 +157,13 @@
      * Check validity of value
      *
      * @param {number|string} value to check
+     * @param {string=false} format for which the value gets tested
      * @returns {boolean}
      */
-    checkValue(value) {
-      switch (this.input.dataset.format) {
+    checkValue(value, format) {
+      const test = format || this.format;
+
+      switch (test) {
         case 'hue':
           return value <= 360 && hueRegex.test(value);
         case 'saturation':
@@ -186,7 +190,7 @@
       let pattern;
 
       // RegExp has '/' at start and end
-      switch (this.input.dataset.format) {
+      switch (this.format) {
         case 'hue':
           pattern = hueRegex.source.slice(1, -1);
           break;
@@ -264,7 +268,7 @@
         return;
       }
 
-      const value = this.checkValue(this.color) ? this.color : this.default;
+      const value = this.checkValue(this.color, this.saveFormat) ? this.color : this.default;
 
       if (!value) {
         this.showError('JFIELD_COLOR_ERROR_NO_COLOUR');


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/25583

### Summary of Changes
The colorpicker displayed the default value instead of the (correct) saved value and this PR fixes this. It just checked the wrong format (there is one for display colors and one for saving them in database).

### Testing Instructions
Go to the backend Atum template settings -> Colour Settings and "Choose your hue value for the dark template colour". Change the value. Click save and check the value which is displayed on the colorpicker and in the input field after the page reloads.

### Expected result
The selected value should be visible.

### Actual result
The default value for this field gets loaded.
