### PR TITLE
Remove background from subhead on large screens

### DIFF
--- a/administrator/templates/atum/scss/blocks/_toolbar.scss
+++ b/administrator/templates/atum/scss/blocks/_toolbar.scss
@@ -14,12 +14,6 @@ joomla-toolbar-button {
   min-height: 43px;
   padding: 13px 0;
   color: var(--atum-text-dark); //#0c192e;
-  
-  @include media-breakpoint-down(lg) {
-    background: var(--toolbar-bg);
-    border-bottom: 1px solid $gray-400;
-    margin-bottom: 1rem;
-  }
 
   .row {
     margin-right: 0;

--- a/administrator/templates/atum/scss/blocks/_toolbar.scss
+++ b/administrator/templates/atum/scss/blocks/_toolbar.scss
@@ -14,8 +14,12 @@ joomla-toolbar-button {
   min-height: 43px;
   padding: 13px 0;
   color: var(--atum-text-dark); //#0c192e;
-  background: var(--toolbar-bg);
-  border-bottom: 1px solid $gray-400;
+  
+  @include media-breakpoint-down(lg) {
+    background: var(--toolbar-bg);
+    border-bottom: 1px solid $gray-400;
+    margin-bottom: 1rem;
+  }
 
   .row {
     margin-right: 0;


### PR DESCRIPTION
When we started, we had not a horizonal filter bar and tabs were at the bottom of the screen. So we used a background and border to make a visible box for the toolbar. 

Now this box is superfluous on large screens.

# Summary of Changes
Remove the background and border from subheader but only on large screens. 

![subheader](https://user-images.githubusercontent.com/1035262/62279947-526e0680-b44b-11e9-8ac7-6f3555ff6528.JPG)

