### PR TITLE
White background for long description in modules edit

### DIFF
--- a/administrator/components/com_modules/tmpl/module/edit.php
+++ b/administrator/components/com_modules/tmpl/module/edit.php
@@ -164,7 +164,10 @@ $tmpl    = $isModal || $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=c
 
 		<?php if (isset($long_description) && $long_description != '') : ?>
 			<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'description', Text::_('JGLOBAL_FIELDSET_DESCRIPTION')); ?>
-			<?php echo $long_description; ?>
+				<fieldset  id="fieldset-description" class="options-grid-form options-grid-form-full">
+					<legend><?php echo Text::_('JGLOBAL_FIELDSET_DESCRIPTION'); ?></legend>
+					<?php echo $long_description; ?>
+				</fieldset>
 			<?php echo HTMLHelper::_('uitab.endTab'); ?>
 		<?php endif; ?>
 

--- a/administrator/components/com_modules/tmpl/module/edit.php
+++ b/administrator/components/com_modules/tmpl/module/edit.php
@@ -164,10 +164,11 @@ $tmpl    = $isModal || $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=c
 
 		<?php if (isset($long_description) && $long_description != '') : ?>
 			<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'description', Text::_('JGLOBAL_FIELDSET_DESCRIPTION')); ?>
-				<fieldset  id="fieldset-description" class="options-grid-form options-grid-form-full">
-					<legend><?php echo Text::_('JGLOBAL_FIELDSET_DESCRIPTION'); ?></legend>
-					<?php echo $long_description; ?>
-				</fieldset>
+				<div class="card">
+					<div class="card-body">
+						<?php echo $long_description; ?>
+					</div>
+				</div>
 			<?php echo HTMLHelper::_('uitab.endTab'); ?>
 		<?php endif; ?>
 


### PR DESCRIPTION
### Summary of Changes

If a module has a long description, a tab is generated. This PR adds awhite background to long description

### Testing Instructions

See for example mod_related_items

![tab-description](https://user-images.githubusercontent.com/1035262/62383951-6b60df80-b551-11e9-9b54-faf75eab8a15.JPG)
