### PR TITLE
Make body height 100%

### DIFF
--- a/administrator/templates/atum/scss/blocks/_global.scss
+++ b/administrator/templates/atum/scss/blocks/_global.scss
@@ -2,9 +2,12 @@
 
 @import "../variables";
 
-html,
+html {
+   height: 100%;
+}
+
 body {
-  height: 100%;
+   min-height: 100%;
 }
 
 body {


### PR DESCRIPTION
On FireFox and Edge (not on chrome) the background is not 100% when scrolling down.

![background-body](https://user-images.githubusercontent.com/1035262/62420950-dff36580-b69a-11e9-8af7-e2ff6a7f37b9.JPG)


### Summary of Changes
Fix background height 