### PR TITLE
set Client_id for modules  

### DIFF
--- a/administrator/components/com_modules/Model/SelectModel.php
+++ b/administrator/components/com_modules/Model/SelectModel.php
@@ -43,7 +43,7 @@ class SelectModel extends ListModel
 		$app = Factory::getApplication();
 
 		// Load the filter state.
-		$clientId = $app->getUserState('com_modules.modules.client_id', 0);
+		$clientId = $app->getUserStateFromRequest('com_modules.modules.client_id', 'client_id', 0);
 		$this->setState('client_id', (int) $clientId);
 
 		// Load the parameters.

--- a/administrator/components/com_modules/Model/SelectModel.php
+++ b/administrator/components/com_modules/Model/SelectModel.php
@@ -42,9 +42,8 @@ class SelectModel extends ListModel
 	{
 		$app = Factory::getApplication();
 
-		// Watch changes in client_id and menutype and keep sync whenever needed.
-		$currentClientId = $app->getUserState($this->context . '.client_id', 0);
-		$clientId        = $app->input->getInt('client_id', $currentClientId);
+		// Load the filter state.
+		$clientId = $app->getUserState('com_modules.modules.client_id', 0);
 		$this->setState('client_id', (int) $clientId);
 
 		// Load the parameters.

--- a/administrator/modules/mod_quickicon/Helper/QuickIconHelper.php
+++ b/administrator/modules/mod_quickicon/Helper/QuickIconHelper.php
@@ -158,7 +158,7 @@ abstract class QuickIconHelper
 				$tmp = [
 					'image'   => 'fa fa-cube',
 					'link'    => Route::_('index.php?option=com_modules&client_id=0'),
-					'linkadd' => Route::_('index.php?option=com_modules&view=select'),
+					'linkadd' => Route::_('index.php?option=com_modules&view=select&client_id=0'),
 					'name'    => 'MOD_QUICKICON_MODULE_MANAGER',
 					'access'  => array('core.manage', 'com_modules'),
 					'group'   => 'MOD_QUICKICON_SITE'

--- a/administrator/modules/mod_quickicon/Helper/QuickIconHelper.php
+++ b/administrator/modules/mod_quickicon/Helper/QuickIconHelper.php
@@ -152,9 +152,6 @@ abstract class QuickIconHelper
 
 			if ($params->get('show_modules'))
 			{
-				// Set the client_id for frontend modules only
-				Factory::getApplication()->setUserState('com_modules.modules.client_id', '0');
-				
 				$tmp = [
 					'image'   => 'fa fa-cube',
 					'link'    => Route::_('index.php?option=com_modules&client_id=0'),

--- a/administrator/modules/mod_quickicon/Helper/QuickIconHelper.php
+++ b/administrator/modules/mod_quickicon/Helper/QuickIconHelper.php
@@ -152,10 +152,13 @@ abstract class QuickIconHelper
 
 			if ($params->get('show_modules'))
 			{
+				// Set the client_id for frontend modules only
+				Factory::getApplication()->setUserState('com_modules.modules.client_id', '0');
+				
 				$tmp = [
 					'image'   => 'fa fa-cube',
 					'link'    => Route::_('index.php?option=com_modules&client_id=0'),
-					'linkadd' => Route::_('index.php?option=com_modules&view=select&client_id=0'),
+					'linkadd' => Route::_('index.php?option=com_modules&view=select'),
 					'name'    => 'MOD_QUICKICON_MODULE_MANAGER',
 					'access'  => array('core.manage', 'com_modules'),
 					'group'   => 'MOD_QUICKICON_SITE'


### PR DESCRIPTION
 ### Summary of Changes
Get client_id for modules from userState


### Testing Instructions
Activate the button "add module" on quick icons. The selection of **frontend** modules is presented.
Activate the "add module" panel on the dashboard. The selection of **backend** modules is presented. 
